### PR TITLE
Bugfix: allow `definition` dependency name

### DIFF
--- a/index.js
+++ b/index.js
@@ -772,8 +772,6 @@ let createContainer = ({resolvers = [], dependencies = {}, factories, definition
             ];
 
             return all(promises, ([dependencies]) => {
-                dependencies.definition = definition;
-
                 let _factory = () => {
                     if (definition.instance) {
                         return definition.instance;


### PR DESCRIPTION
Seems like this line does nothing, but restricts to name dependency `definition`:

https://github.com/ftdebugger/di.js/blob/master/index.js#L775
