### PR TITLE
Bugfix: improve extractModule function

### DIFF
--- a/index.js
+++ b/index.js
@@ -612,6 +612,9 @@ let normalizeDefinitions = (dependencies) => {
  */
 let extractModule = (Module) => {
     if (Module.__esModule === true) {
+        if (Module.default) {
+            return Module.default;
+        }
         return find(Module, value => isFunction(value) || isObject(value));
     }
 

--- a/test/di.spec.js
+++ b/test/di.spec.js
@@ -1510,6 +1510,14 @@ describe('DI', function () {
             };
             expect(extractModule(module)).to.equal(module.SomeModule);
         });
+
+        it('extracts es6 default module even if it is not the first exported module', function () {
+            var module = {
+                __esModule: true, SomeModule: {}, default: {}
+            };
+            expect(extractModule(module)).to.equal(module.default);
+        });
+
     });
 
     describe('definition by instance', function () {


### PR DESCRIPTION
Seems like current implementation will break in some cases. Just for example:

``` js
let Module = {};
Module.__esModule = true;
Module.abc = function(){};
Module.default = function(){};
```
